### PR TITLE
Added latitude and longitude keys to merge statements

### DIFF
--- a/R/generateaWhereDataset.R
+++ b/R/generateaWhereDataset.R
@@ -133,10 +133,10 @@ generateaWhereDataset <- function(lat
 
     #create final dataset
 
-    weather_full <- merge(obs, ag, by = c("date", 'day'), all = TRUE) %>%
-      merge(., forecast,       by = c("date", "day"), all = TRUE) %>%
-      merge(., obs_ltn,    by = "day")  %>%
-      merge(., ag_ltn,  by = "day") %>%
+    weather_full <- merge(obs, ag, by = c("date", "day", "latitude", "longitude"), all = TRUE) %>%
+      merge(., forecast, by = c("date", "day", "latitude", "longitude"), all = TRUE) %>%
+      merge(., obs_ltn, by = c("day", "latitude", "longitude"))  %>%
+      merge(., ag_ltn,  by = c("day", "latitude", "longitude")) %>%
       .[order(.$date),] %>%
       dplyr::mutate(maxTemp = ifelse(!is.na(maxTemp), maxTemp, temperatures.max),
                     minTemp = ifelse(!is.na(minTemp), minTemp, temperatures.min),


### PR DESCRIPTION
When merging in the obs_ltn and ag_ltn it was getting confused by repeated latitude.x columns which happens when a column is in both data frames being merged but not in the "by" part of the merge statement