### PR TITLE
Fixed bug where forecast data wasn't being returned

### DIFF
--- a/R/generateaWhereDataset.R
+++ b/R/generateaWhereDataset.R
@@ -438,18 +438,16 @@ generateaWhereDataset <- function(lat
     cat(paste0('    Combining together data\n'))
   }
   
-  weather_full <- merge(obs,          ag,      by = c("date", "day", "latitude", "longitude"), all = TRUE)
-  weather_full <- merge(weather_full, obs_ltn, by = c("day", "latitude", "longitude"))
-  weather_full <- merge(weather_full, ag_ltn,  by = c("day", "latitude", "longitude"))
+  weather_full <- merge(obs,          ag,       by = c("date", "day", "latitude", "longitude"), all = TRUE)
+  weather_full <- merge(weather_full, forecast, by = c("date", "day", "latitude", "longitude"), all = TRUE)
+  weather_full <- merge(weather_full, obs_ltn,  by = c("day", "latitude", "longitude"))
+  weather_full <- merge(weather_full, ag_ltn,   by = c("day", "latitude", "longitude"))
   
   setkey(weather_full,date)
   
-  weather_full.names <- colnames(weather_full)
+  weather_full.names <- unique(c(colnames(obs), colnames(ag), colnames(obs_ltn), colnames(ag_ltn)))
   
-  weather_full <- merge(weather_full
-                        ,forecast
-                        ,by = c("date", "day", "latitude", "longitude")
-                        ,all = TRUE)
+
   
   #This is meant to add the forecast data to the observed columns
   


### PR DESCRIPTION
By merging in the ltn data before the forecast data, it was removing the monthday records for the forecast data. This caused an issue when trying to subsequently join the forecast data as there were no longer any monthday records corresponding to the forecast period.